### PR TITLE
Supports angular expressions in ckeditor attribute

### DIFF
--- a/ng-ckeditor.js
+++ b/ng-ckeditor.js
@@ -77,7 +77,7 @@
                         height: '400px',
                         width: '100%'
                     };
-                    options = angular.extend(options, scope[attrs.ckeditor]);
+                    options = angular.extend(options, scope.$eval(attrs.ckeditor));
 
                     var instance = (isTextarea) ? CKEDITOR.replace(element[0], options) : CKEDITOR.inline(element[0], options),
                         configLoaderDef = $q.defer();


### PR DESCRIPTION
- uses $scope.$eval when accessing the value specified by the ckeditor attribute
- supports use cases like the following:
  <textarea ckeditor="myController.ckEditorOptions">
  <textarea ckeditor="getCkEditorOptions()">
